### PR TITLE
Update news source api

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The left panel displays ask and bid prices for each pair by reading the dataset 
 You can also visualize market prices with candlesticks, line, OHLC bars and make some studies on it with the selected period in the dropdown.
 You can choose these options in the graph div menu by clicking on ☰ .
 
-Finally, top news from Financial Times are displayed on the left and updated on interval updates, using https://newsapi.org/ 
+Finally, top news from BBC news are displayed on the left and updated on interval updates, using https://newsapi.org/ 
 
 ### Running the app locally
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The left panel displays ask and bid prices for each pair by reading the dataset 
 You can also visualize market prices with candlesticks, line, OHLC bars and make some studies on it with the selected period in the dropdown.
 You can choose these options in the graph div menu by clicking on ☰ .
 
-Finally, top news from BBC news are displayed on the left and updated on interval updates, using https://newsapi.org/ 
+Finally, top news articles from BBC are displayed on the left and updated on interval updates, using https://newsapi.org/ 
 
 ### Running the app locally
 

--- a/app.py
+++ b/app.py
@@ -88,7 +88,7 @@ def generate_news_table(dataframe, max_rows=10):
 
 # retrieve and displays news 
 def update_news():
-    r = requests.get('https://newsapi.org/v2/top-headlines?sources=financial-times&apiKey=da8e2e705b914f9f86ed2e9692e66012')
+    r = requests.get('https://newsapi.org/v2/top-headlines?sources=bbc-news&apiKey=da8e2e705b914f9f86ed2e9692e66012')
     json_data = r.json()["articles"]
     df = pd.DataFrame(json_data)
     df = pd.DataFrame(df[["title","url"]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ six==1.11.0
 traitlets==4.3.2
 urllib3==1.23
 Werkzeug==0.14.1
-numpy==1.12.0
-pandas==0.22.0
+numpy==1.16.3
+pandas==0.24.2


### PR DESCRIPTION
This app fails because fetching from newsapi returns empty article entity. 

Previous request: https://newsapi.org/v2/top-headlines?sources=financial-times&apiKey=da8e2e705b914f9f86ed2e9692e66012
returns {"status":"ok","totalResults":0,"articles":[]}

The source 'financial-times' no longer exists in newsapi/v2/, so I updated api with alternative news source.

new request: 'https://newsapi.org/v2/top-headlines?sources=bbc-news&apiKey=da8e2e705b914f9f86ed2e9692e66012'

Deployed : https://dash-gallery.plotly.host/dash-web-trader/