### PR TITLE
Add handling for news request

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,6 @@ def generate_news_table(dataframe, max_rows=10):
             ),
             html.P(
                 id = "news_update",
-                children= "Last update : " + datetime.datetime.now().strftime("%H:%M:%S"),
                 style={"fontSize": "11", "marginTop": "4", "color": "#45df7e"},
             ),
         ],
@@ -1005,7 +1004,7 @@ app.layout = html.Div(
                 ),
                 html.Div([
                     html.P('Headlines',style={"fontSize":"13","color":"#45df7e"}),
-                    html.Div(update_news(),id="news")
+                    html.Div(id="news")
                     ],
                     style={
                         "height":"33%",
@@ -1721,9 +1720,13 @@ def update_time(n):
 
 
 @app.callback(Output("news_update", "children"), [Input("i_news", "n_intervals")])
-def update_news_div(n):
+def update_news_timestamp(n):
     return "Last update : " + datetime.datetime.now().strftime('%m/%d/%y %H:%M:%S')
 
+
+@app.callback(Output("news", "children"), [Input("i_news", "n_intervals")])
+def update_news_div(n):
+    return update_news()
 
 if __name__ == "__main__":
     app.run_server(debug=True, threaded=True)

--- a/app.py
+++ b/app.py
@@ -79,7 +79,8 @@ def generate_news_table(dataframe, max_rows=10):
                 style={"height": "150px", "overflowY": "scroll"},
             ),
             html.P(
-                "Last update : " + datetime.datetime.now().strftime("%H:%M:%S"),
+                id = "news_update",
+                children= "Last update : " + datetime.datetime.now().strftime("%H:%M:%S"),
                 style={"fontSize": "11", "marginTop": "4", "color": "#45df7e"},
             ),
         ],
@@ -88,10 +89,15 @@ def generate_news_table(dataframe, max_rows=10):
 
 # retrieve and displays news 
 def update_news():
-    r = requests.get('https://newsapi.org/v2/top-headlines?sources=bbc-news&apiKey=da8e2e705b914f9f86ed2e9692e66012')
-    json_data = r.json()["articles"]
-    df = pd.DataFrame(json_data)
-    df = pd.DataFrame(df[["title","url"]])
+    url = 'https://newsapi.org/v2/top-headlines?sources=bbc-news&apiKey=da8e2e705b914f9f86ed2e9692e66012'
+    try:
+        r = requests.get(url)
+        json_data = r.json()["articles"]
+        df = pd.DataFrame(json_data)
+        df = pd.DataFrame(df[["title", "url"]])
+    except Exception as e:
+        data = {"title": ["news api not retrievable"], "url": [url]}
+        df = pd.DataFrame(data=data, columns=["title", "url"])
     return generate_news_table(df)
 
 
@@ -972,7 +978,7 @@ app.layout = html.Div(
         # Interval component for graph updates
         dcc.Interval(id="i_tris", interval=1 * 5000, n_intervals=0),
         # Interval component for graph updates
-        dcc.Interval(id="i_news", interval=1 * 60000, n_intervals=0),
+        dcc.Interval(id="i_news", interval=24 * 60 * 60 * 1000, n_intervals=0),
 
 
         # left Div
@@ -1713,9 +1719,10 @@ def update_top_bar(orders):
 def update_time(n):
     return datetime.datetime.now().strftime("%H:%M:%S")
 
-@app.callback(Output("news", "children"), [Input("i_news", "n_intervals")])
+
+@app.callback(Output("news_update", "children"), [Input("i_news", "n_intervals")])
 def update_news_div(n):
-    return update_news()
+    return "Last update : " + datetime.datetime.now().strftime('%m/%d/%y %H:%M:%S')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves https://github.com/plotly/dash-web-trader/issues/6

1. Add handling for news api so that app won't be brought down in case of failure request.
2. Change api request to daily update.
This app currently calls news api at session start and once every 24hr. It'll return empty table if request fails.

<img width="316" alt="Screen Shot 2019-05-29 at 4 26 43 PM" src="https://user-images.githubusercontent.com/35306149/58590857-0926ee00-8233-11e9-9ae6-a846be4169cf.png">
